### PR TITLE
Implement DFT plane stacking

### DIFF
--- a/dft-view/freq_dft_view.ppy
+++ b/dft-view/freq_dft_view.ppy
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from vspreview.plugins import MappedNodesViewPlugin, PluginConfig
-from vstools import depth, plane, vs
+from vstools import depth, split, stack_clips, vs
 
 __all__ = [
     'DFTViewPlugin'
@@ -11,24 +11,43 @@ __all__ = [
 class DFTViewPlugin(MappedNodesViewPlugin):
     _config = PluginConfig('dev.setsugen.fft_view', 'DFT View')
 
-    _autofit = True
-
     def get_node(self, node: vs.VideoNode) -> vs.VideoNode:
         import numpy as np
         from cv2 import DFT_COMPLEX_OUTPUT, dft  # type: ignore
 
-        y = depth(plane(node, 0, strict=False), 32)
+        planes = split(depth(node, 32))
 
         def _to_polar(f: vs.VideoFrame, n: int) -> vs.VideoFrame:
             src = np.asarray(f[0])
-
             dft_shift = np.fft.fftshift(dft(src, flags=DFT_COMPLEX_OUTPUT))
             mag = np.sqrt(np.power(dft_shift[:, :, 1], 2), np.power(dft_shift[:, :, 0], 2))
-
             dst = f.copy()
-
             np.copyto(np.asarray(dst[0]), np.log(mag) / 10)
-
             return dst
 
-        return y.std.ModifyFrame(y, _to_polar)
+        if len(planes) == 1:
+            y = planes[0]
+
+            return y.std.ModifyFrame(y, _to_polar)
+
+        planes = [c.std.ModifyFrame(c, _to_polar).text.Text(text=k) for k, c in zip(node.format.name, planes)]
+
+        subsampling = node.format.subsampling_w, node.format.subsampling_h
+
+        org: list[vs.VideoNode | list[vs.VideoNode | list[vs.VideoNode]]] = planes
+
+        if subsampling in ((2, 2), (2, 0)):
+            middle = [
+                planes[1].std.BlankClip(),
+                *planes[1:],
+                planes[1].std.BlankClip()
+            ]
+
+            org = [planes[0], middle]
+        elif subsampling != (0, 0):
+            org = [planes[0], planes[1:]]
+
+        if subsampling[1] == 0:
+            org = [org]
+
+        return stack_clips(org)


### PR DESCRIPTION
Basically implements #9.

This is easier to use and doesn't force you to refresh and export a specific plane just to quickly check if a clip is lowpassed or similar.